### PR TITLE
fix(api): use Admin SDK for waitlist, improve forgot-password logging

### DIFF
--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { isOnWaitlist, addToWaitlist } from '@/lib/firebase/services/waitlist';
+import { isOnWaitlistAdmin, addToWaitlistAdmin } from '@/lib/firebase/admin-services/waitlist';
 
 // Validation schema
 const waitlistSchema = z.object({
@@ -17,8 +17,8 @@ export async function POST(req: NextRequest) {
     // Validate input
     const validatedData = waitlistSchema.parse(body);
 
-    // Check if email already exists (Firestore)
-    const exists = await isOnWaitlist(validatedData.email);
+    // Check if email already exists (Admin SDK)
+    const exists = await isOnWaitlistAdmin(validatedData.email);
 
     if (exists) {
       return NextResponse.json(
@@ -27,8 +27,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Create waitlist entry (Firestore)
-    await addToWaitlist({
+    // Create waitlist entry (Admin SDK)
+    await addToWaitlistAdmin({
       email: validatedData.email,
       firstName: validatedData.firstName,
       lastName: validatedData.lastName,

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -22,18 +22,20 @@ export default function ForgotPasswordPage() {
 
       const data = await response.json();
 
-      if (response.ok) {
+      if (response.ok && data.success) {
         setStatus('success');
         setMessage(data.message || 'Password reset email sent successfully');
         setEmail(''); // Clear form
       } else {
         setStatus('error');
-        setMessage(data.error || 'Failed to send password reset email');
+        // Use message field first, then error field
+        setMessage(data.message || data.error || 'Failed to send password reset email');
+        console.error('Forgot password API error:', { status: response.status, data });
       }
     } catch (error) {
-      console.error('Forgot password error:', error);
+      console.error('Forgot password network error:', error);
       setStatus('error');
-      setMessage('An error occurred. Please try again.');
+      setMessage('Network error. Please check your connection and try again.');
     }
   };
 

--- a/src/lib/firebase/admin-services/waitlist.ts
+++ b/src/lib/firebase/admin-services/waitlist.ts
@@ -1,0 +1,66 @@
+/**
+ * Firebase Admin SDK - Waitlist Service (Server-Side)
+ *
+ * Server-side Firestore operations for waitlist documents.
+ * Used in Next.js API routes.
+ * Collection: /waitlist/{email}
+ */
+
+import { adminDb } from '../admin';
+
+export interface WaitlistDocument {
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  source?: string | null;
+  createdAt: Date;
+}
+
+/**
+ * Check if email exists on waitlist (Admin SDK)
+ */
+export async function isOnWaitlistAdmin(email: string): Promise<boolean> {
+  const docRef = adminDb.collection('waitlist').doc(email);
+  const docSnap = await docRef.get();
+  return docSnap.exists;
+}
+
+/**
+ * Add email to waitlist (Admin SDK)
+ */
+export async function addToWaitlistAdmin(data: {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  source?: string;
+}): Promise<void> {
+  const docRef = adminDb.collection('waitlist').doc(data.email);
+  await docRef.set({
+    email: data.email,
+    firstName: data.firstName || null,
+    lastName: data.lastName || null,
+    source: data.source || 'landing_page',
+    createdAt: new Date(),
+  });
+}
+
+/**
+ * Get waitlist entry by email (Admin SDK)
+ */
+export async function getWaitlistEntryAdmin(email: string): Promise<WaitlistDocument | null> {
+  const docRef = adminDb.collection('waitlist').doc(email);
+  const docSnap = await docRef.get();
+
+  if (!docSnap.exists) {
+    return null;
+  }
+
+  const data = docSnap.data()!;
+  return {
+    email: data.email,
+    firstName: data.firstName || null,
+    lastName: data.lastName || null,
+    source: data.source || null,
+    createdAt: data.createdAt?.toDate?.() || new Date(data.createdAt),
+  };
+}


### PR DESCRIPTION
## Summary
- **Waitlist fix**: Home page "Get notified" form was failing with "load failed" because API used client SDK
- **Forgot password fix**: Added detailed logging to diagnose reset email failures
- Created `admin-services/waitlist.ts` with Admin SDK functions

## Root Cause
API routes were using client Firebase SDK which requires browser auth context. Server routes must use Admin SDK.

## Test plan
- [ ] Test "Get notified" form on home page - should submit successfully
- [ ] Test forgot password - should send email or show detailed error
- [ ] Check server logs for new logging output

🤖 Generated with [Claude Code](https://claude.ai/code)