### PR TITLE
chore(ci): bump pinned jeremylongshore/.github vps-deploy SHA → 53d6be3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
 
   deploy:
     needs: build-gate
-    uses: jeremylongshore/.github/.github/workflows/vps-deploy.yml@709a07fbebb1d51806e171204e63f5332abcb0da
+    uses: jeremylongshore/.github/.github/workflows/vps-deploy.yml@53d6be37d6c046818157b954acb33667ac095dd8
     with:
       variant: docker
       srv-path: /srv/hustle


### PR DESCRIPTION
Upstream `jeremylongshore/.github` vps-deploy.yml had a documentation-only commit (PR #1, 2026-06-12) bumping the consumer-example snippet to `actions/checkout@v6` ahead of the GitHub Actions Node-20 deprecation cutover on **2026-06-16**.

This bump is functionally a no-op for deploy behavior — every live action in the upstream workflow is unchanged — but moving the pin forward keeps the fleet aligned so future real upstream changes land cleanly.

| | |
|---|---|
| Old SHA | `709a07fbebb1d51806e171204e63f5332abcb0da` |
| New SHA | `53d6be37d6c046818157b954acb33667ac095dd8` |
| Diff | comment-block example in upstream workflow only |

- Jeremy Longshore
intentsolutions.io