### PR TITLE
security: scrub committed Firebase web key from tracked files + rotation inventory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Firebase Configuration (Client-side - public)
-NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
 NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="hustleapp-production.firebasestorage.app"

--- a/000-docs/187-AA-MAAR-hustle-auth-wiring-local-e2e.md
+++ b/000-docs/187-AA-MAAR-hustle-auth-wiring-local-e2e.md
@@ -72,7 +72,7 @@ EMAIL_FROM="HUSTLE <noreply@intentsolutions.io>"
 **Missing Variables (9 critical):**
 ```env
 # CLIENT SDK (6 variables)
-NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
 NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="hustleapp-production.firebasestorage.app"
@@ -385,7 +385,7 @@ HEAD / 200 in 9647ms
 1. **Add Firebase Environment Variables**
    ```bash
    # Copy from .env.example to .env.local
-   NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+   NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
    NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="hustleapp-production.firebasestorage.app"

--- a/000-docs/188-AA-MAAR-hustle-auth-wiring-staging-e2e.md
+++ b/000-docs/188-AA-MAAR-hustle-auth-wiring-staging-e2e.md
@@ -81,7 +81,7 @@ cache-control: max-age=0
 **Firebase SDK Configuration:**
 ```typescript
 // From .env.example (production values)
-NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
 NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
 NEXT_PUBLIC_FIREBASE_APP_ID="1:335713777643:web:209e728afd5aee07c80bae"
@@ -501,7 +501,7 @@ https://console.firebase.google.com/project/hustleapp-production/firestore/datab
 1. **Add Firebase Secrets to GitHub Repository**
    ```bash
    # User must run these commands with appropriate values
-   gh secret set FIREBASE_API_KEY --body "AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+   gh secret set FIREBASE_API_KEY --body "REDACTED_ROTATED_GOOGLE_KEY"
    gh secret set FIREBASE_AUTH_DOMAIN --body "hustleapp-production.firebaseapp.com"
    gh secret set FIREBASE_PROJECT_ID --body "hustleapp-production"
    gh secret set FIREBASE_STORAGE_BUCKET --body "hustleapp-production.firebasestorage.app"

--- a/000-docs/189-AA-SUMM-hustle-step-1-auth-wiring-complete.md
+++ b/000-docs/189-AA-SUMM-hustle-step-1-auth-wiring-complete.md
@@ -155,7 +155,7 @@
 **Required Variables:**
 ```env
 # Client SDK (6 variables) - MISSING
-NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
 NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="hustleapp-production.firebasestorage.app"
@@ -503,7 +503,7 @@ npm run dev
 **Steps:**
 ```bash
 # Add client-side variables to GitHub Secrets
-gh secret set FIREBASE_API_KEY --body "AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+gh secret set FIREBASE_API_KEY --body "REDACTED_ROTATED_GOOGLE_KEY"
 gh secret set FIREBASE_AUTH_DOMAIN --body "hustleapp-production.firebaseapp.com"
 gh secret set FIREBASE_PROJECT_ID --body "hustleapp-production"
 gh secret set FIREBASE_STORAGE_BUCKET --body "hustleapp-production.firebasestorage.app"

--- a/000-docs/190-AA-MAAR-hustle-env-firebase-local-unblock.md
+++ b/000-docs/190-AA-MAAR-hustle-env-firebase-local-unblock.md
@@ -27,7 +27,7 @@
 **Added to `.env.local` (7 variables):**
 ```env
 # Firebase Client SDK (Public - safe to commit)
-NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
 NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="hustleapp-production.firebasestorage.app"

--- a/000-docs/217-AA-COMP-hustle-complete-journey-phase1-to-phase5.md
+++ b/000-docs/217-AA-COMP-hustle-complete-journey-phase1-to-phase5.md
@@ -3148,7 +3148,7 @@ File: `000-docs/205-OD-SECR-github-secrets-firebase-mapping.md`
 These are **public** values (can be exposed client-side):
 
 ```
-NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
 NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="hustleapp-production.firebasestorage.app"

--- a/000-docs/257-DR-GUID-mobile-app-setup-guide.md
+++ b/000-docs/257-DR-GUID-mobile-app-setup-guide.md
@@ -44,7 +44,7 @@ cp .env.example .env
 Edit `.env` with production Firebase values:
 
 ```bash
-EXPO_PUBLIC_FIREBASE_API_KEY=AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo
+EXPO_PUBLIC_FIREBASE_API_KEY=REDACTED_ROTATED_GOOGLE_KEY
 EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=hustleapp-production.firebaseapp.com
 EXPO_PUBLIC_FIREBASE_PROJECT_ID=hustleapp-production
 EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=hustleapp-production.firebasestorage.app

--- a/000-docs/SECURITY-key-rotation-inventory-2026-07-18.md
+++ b/000-docs/SECURITY-key-rotation-inventory-2026-07-18.md
@@ -1,0 +1,13 @@
+# Committed-key rotation inventory (2026-07-18)
+
+Keys found in git-tracked files and redacted at HEAD (branch `security/scrub-committed-keys`). Values are MASKED here. **History still holds the originals** until a separate purge; treat every key below as compromised and rotate it.
+
+| Type | Prefix | sha256[:8] | Files |
+|---|---|---|---|
+| google-firebase | `AIzaSyDv...` | `8ade0316` | .env.example, 000-docs/187-AA-MAAR-hustle-auth-wiring-local-e2e.md, 000-docs/188-AA-MAAR-hustle-auth-wiring-staging-e2e.md, 000-docs/189-AA-SUMM-hustle-step-1-auth-wiring-complete.md, 000-docs/190-AA-MAAR-hustle-env-firebase-local-unblock.md, 000-docs/217-AA-COMP-hustle-complete-journey-phase1-to-phase5.md, 000-docs/257-DR-GUID-mobile-app-setup-guide.md, Dockerfile |
+
+## Rotation status
+
+- The key GitHub secret-scanning flagged was already auto-revoked by the provider.
+- Firebase/Google `AIza…` *web* keys are public by design (client identifiers); restrict them by referrer/app in the Google/Firebase console rather than rotating.
+- All `sk-…` (OpenAI/Anthropic) keys are real secrets: rotate in the provider dashboard and update the runtime config (SOPS/`.env`, never committed).

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 # These are NEXT_PUBLIC values (already exposed in client bundle) and exist
 # only so that build-time Firebase SDK initialization compiles. Phase 3
 # (auth port to Lucia) strips both these args and the Firebase code paths.
-ARG NEXT_PUBLIC_FIREBASE_API_KEY="AIzaSyDviqCSH3GDsT2zHScYV-fCzpc0UU__2Wo"
+ARG NEXT_PUBLIC_FIREBASE_API_KEY="REDACTED_ROTATED_GOOGLE_KEY"
 ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="hustleapp-production.firebaseapp.com"
 ARG NEXT_PUBLIC_FIREBASE_PROJECT_ID="hustleapp-production"
 ARG NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="hustleapp-production.firebasestorage.app"

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
## What

Redacts a hardcoded Google/Firebase API key (`AIzaSyDv…`, sha256 `8ade0316`) from **8 git-tracked files** (`.env.example`, `Dockerfile`, and 6 `000-docs/*.md`) and adds a masked rotation inventory (`000-docs/SECURITY-key-rotation-inventory-2026-07-18.md`).

## Why

GitHub secret scanning flagged an exposed key in a downstream copy of this repo. A scan of `jeremylongshore/hustle` found exactly one distinct real key committed to tracked files (repeated across the 8 above). Gitignored `.env` / `.env.local` were already safe; the `sk-*` strings elsewhere are short placeholders (<20 chars), not real secrets.

## Severity (honest)

**LOW.** The one committed secret is a Firebase **web** API key, which is public by design (a client-side identifier secured by Firebase security rules, not by secrecy), and was temporary build-time config during the VPS migration (Phase 3 removes Firebase entirely). The provider-revoked key from the scanning alert lives in a **third-party copy** of these docs, not in this repo's tracked files.

## How verified

`git grep` for real-length key patterns (`sk-*{20,}`, `AIza*{30,}`, `ghp_*`) returns **zero** tracked matches after the scrub.

## Risk / operational impact / unfinished

- **Git history still holds the original value** on every past commit. Purging it there needs a separate `git filter-repo` + force-push (breaks clones/forks) and is gated on owner approval. Deliberately not done here.
- If the current Docker image still initializes Firebase at runtime, inject the real web key via a build ARG / deploy env at build time (do **not** re-commit it); Phase 3 obviates it.
- **Rotation:** see the inventory doc. Firebase web keys are restricted by referrer/app in the console rather than rotated.

## Refs

Estate secret-hygiene follow-up to a GitHub secret-scanning alert.

- Jeremy Longshore
intentsolutions.io